### PR TITLE
update docs remote deps

### DIFF
--- a/vignettes/z-advanced-topic-handling-packages-with-remote-dependencies.Rmd
+++ b/vignettes/z-advanced-topic-handling-packages-with-remote-dependencies.Rmd
@@ -203,7 +203,7 @@ provided by the user. If you don't have a Github Personal Acccess Token set up, 
 ```
 When fetching the commit date from GitHub from <<< ropensci/rix >>>, no GitHub Personal Access Token found.
 Please set GITHUB_PAT in your environment.
-Falling back to unauthenticated API request
+Falling back to unauthenticated API request.
 ```
 
 This should still work until you hit the API limit, in which case you will see

--- a/vignettes/z-advanced-topic-handling-packages-with-remote-dependencies.Rmd
+++ b/vignettes/z-advanced-topic-handling-packages-with-remote-dependencies.Rmd
@@ -196,24 +196,24 @@ Remotes:
 
 ### Authenticating to GitHub
 
-You will see messages such as this one:
-
-```
-When fetching the commit date from GitHub from <<< jimhester/lookup >>>, no GitHub Personal Access Token found.
-Please set GITHUB_PAT in your environment.
-Falling back to unauthenticated API request.
-```
-
 `{rix}` uses the GitHub API to fetch the commits of these remote packages and
-will attempt to select the closest commit in time for these remote packages
-to the commit provided by the user. However, this can sometimes fail, and
-when this does, the following message will be shown:
+will attempt to select the commit of the remote packages, whose date is closest to (always before, never after) the date  of the commit
+provided by the user. If you don't have a Github Personal Acccess Token set up, it will show:
 
 ```
-Failed to get closest commit for gaborcsardi/gh: Failed to download commit data: Argument 'url' must be string..
-Falling back to <<< HEAD >>>
+When fetching the commit date from GitHub from <<< ropensci/rix >>>, no GitHub Personal Access Token found.
+Please set GITHUB_PAT in your environment.
+Falling back to unauthenticated API request
 ```
 
+This should still work until you hit the API limit, in which case you will see
+messages, such as this one:
+
+````
+Failed to get commit date from <<< satijalab/seurat-wrappers >>> API request failed with status code 403
+```
+
+The status code 403 tells you that there is a credentials error (e.g., because you hit the API limit).
 This is why we highly recommend that you set up a GitHub Personal Access Token:
 this will allow `{rix}` to perform authenticated calls to the API, meaning that
 `{rix}` will be able to get up to 5000 API calls per hour, instead of 60,


### PR DESCRIPTION

A few suggestions, i think it's good to mention that
1)  it uses commit dates before but not after the date given.
2) Warning when github pat not set (but might still work)
3) API 403 if there are credentials errors (like hitting API limit)

Actually i was confused by the error 

I've not seenn the `url must be string` error.  Is this the full error message you get?
 As you write, probably it's because `gaborcsardi/gh` does not exist anymore? I also thought about using `gh` for testing, but it's confusing because it's now `r-lib/gh` so I am not sure this is a good example.